### PR TITLE
feat: increase _get_workflow_run_id timeout to 45min

### DIFF
--- a/src/unit_test.sh
+++ b/src/unit_test.sh
@@ -66,7 +66,7 @@ function _check_unit_test() {
         unit_tests_warn_msg=""
 
         workflow_run_id=""
-        _retry_with_delay _get_workflow_run_id 5
+        _retry_with_delay _get_workflow_run_id 45
 
         if [[ -n "$workflow_run_id" ]]; then
             _retry_with_delay _check_unit_test_status "$UNIT_TEST_CHECK_TIMEOUT"

--- a/src/unit_test.sh
+++ b/src/unit_test.sh
@@ -66,7 +66,7 @@ function _check_unit_test() {
         unit_tests_warn_msg=""
 
         workflow_run_id=""
-        _retry_with_delay _get_workflow_run_id 45
+        _retry_with_delay _get_workflow_run_id 120
 
         if [[ -n "$workflow_run_id" ]]; then
             _retry_with_delay _check_unit_test_status "$UNIT_TEST_CHECK_TIMEOUT"


### PR DESCRIPTION
- In some cases there are jobs that run before the test job, so we need to wait for the test job to be trigged, to verify if has the Quality Gate step.

![image](https://github.com/olxbr/quality-gate-action/assets/4138825/e03517a6-e760-41a7-9383-1daeb50a9a13)
