### PR TITLE
Add message to represent the timeout to the user

### DIFF
--- a/src/unit_test.sh
+++ b/src/unit_test.sh
@@ -76,6 +76,7 @@ function _check_unit_test() {
             if [[ "$status" != "completed" ]]; then
                 _log debug "Inserting timeout message to Unit Test"
                 _insert_warning_message unit_tests_warn_msg "⚠️ Unit Test Job is not completed!"
+            fi
         else
             message="Step ($UNIT_TEST_STEP_NAME) not found!"
             _log warn "${C_YEL}${message}${C_END}"

--- a/src/unit_test.sh
+++ b/src/unit_test.sh
@@ -73,6 +73,9 @@ function _check_unit_test() {
 
         if [[ -n "$workflow_run_id" ]]; then
             _retry_with_delay _check_unit_test_status "$UNIT_TEST_CHECK_TIMEOUT"
+            if [[ "$status" != "completed" ]]; then
+                _log debug "Inserting timeout message to Unit Test"
+                _insert_warning_message unit_tests_warn_msg "⚠️ Unit Test Job is not completed!"
         else
             message="Step ($UNIT_TEST_STEP_NAME) not found!"
             _log warn "${C_YEL}${message}${C_END}"

--- a/src/unit_test.sh
+++ b/src/unit_test.sh
@@ -75,8 +75,9 @@ function _check_unit_test() {
         if [[ -n "$workflow_run_id" ]]; then
             _retry_with_delay _check_unit_test_status "$UNIT_TEST_CHECK_TIMEOUT"
             if [[ "$status" != "completed" ]]; then
-                _log debug "Inserting timeout message to Unit Test"
-                _insert_warning_message unit_tests_warn_msg "⚠️ Unit Test Job is not completed!"
+                message="Unit Test check is not completed!"
+                _log warn "${C_YEL}${message}${C_END}"
+                _insert_warning_message unit_tests_warn_msg "⚠️ ${message}"
             fi
         else
             message="Step ($UNIT_TEST_STEP_NAME) not found!"


### PR DESCRIPTION
This fixes a bug when the action timed out in the unit test and send a "Passed" message in the warning field.