### PR TITLE
Feat: Create gates to skip array to send to DataLake

### DIFF
--- a/src/submit_metrics.sh
+++ b/src/submit_metrics.sh
@@ -20,6 +20,7 @@ export QUALITY_GATE__STATIC_ANALYSIS_VALUE=${QUALITY_GATE__STATIC_ANALYSIS_VALUE
 export QUALITY_GATE__STATIC_ANALYSIS_VALUE=${QUALITY_GATE__STATIC_ANALYSIS_VALUE/.*/} ## Remove decimal places (if any)
 export QUALITY_GATE__STATIC_ANALYSIS_THRESHOLD=${QUALITY_GATE__STATIC_ANALYSIS_THRESHOLD:-null}
 export QUALITY_GATE__STATIC_ANALYSIS_THRESHOLD=${QUALITY_GATE__STATIC_ANALYSIS_THRESHOLD/.*/} ## Remove decimal places (if any)
+export GATES_TO_SKIP_ARR=$(_convert_to_json_array "${GATES_TO_SKIP:-}")
 
 ENDPOINT_URL="${GH_METRICS_SERVER_ENDPOINT}/quality-gates/required-workflow"
 # shellcheck disable=SC2016
@@ -34,6 +35,7 @@ DATA='{
     "pull_request_deletions": ${PR_NUM_DELETIONS},
     "pull_request_changed_files": ${PR_NUM_CHANGED_FILES},
     "quality_gates_to_skip_str": "${GATES_TO_SKIP}",
+    "quality_gates_to_skip_arr": "${GATES_TO_SKIP_ARR}",
     "quality_gate_owner_approval": ${QUALITY_GATE__OWNER_APPROVAL},
     "quality_gate_owner_approval_warn_msgs": "${QUALITY_GATE__OWNER_APPROVAL_WARN_MSGS}",
     "quality_gate_code_review": ${QUALITY_GATE__CODE_REVIEW},

--- a/src/utils.sh
+++ b/src/utils.sh
@@ -125,3 +125,7 @@ function _retry_with_delay() {
         fi
     done
 }
+
+function _convert_to_json_array() {
+    echo "$1" | tr ",;| " "," | jq -R 'split(",")'
+}

--- a/src/utils.sh
+++ b/src/utils.sh
@@ -127,5 +127,10 @@ function _retry_with_delay() {
 }
 
 function _convert_to_json_array() {
-    echo "$1" | tr ",;| " "," | jq -R 'split(",")'
+    local input=$1
+    if [ -n "$input" ]; then
+        echo "$input" | tr ",;| " "," | jq -R 'split(",")'
+    else
+        echo null
+    fi
 }


### PR DESCRIPTION
## WHAT
- add _convert_to_json_array function to utils
- use _convert_to_json_array function to create GATES_TO_SKIP_ARR data

## WHY
- To send to DataLake a normalized information about skipped gates