### PR TITLE
Fix: Send quality gates skip metrics

### DIFF
--- a/src/submit_metrics.sh
+++ b/src/submit_metrics.sh
@@ -20,7 +20,7 @@ export QUALITY_GATE__STATIC_ANALYSIS_VALUE=${QUALITY_GATE__STATIC_ANALYSIS_VALUE
 export QUALITY_GATE__STATIC_ANALYSIS_VALUE=${QUALITY_GATE__STATIC_ANALYSIS_VALUE/.*/} ## Remove decimal places (if any)
 export QUALITY_GATE__STATIC_ANALYSIS_THRESHOLD=${QUALITY_GATE__STATIC_ANALYSIS_THRESHOLD:-null}
 export QUALITY_GATE__STATIC_ANALYSIS_THRESHOLD=${QUALITY_GATE__STATIC_ANALYSIS_THRESHOLD/.*/} ## Remove decimal places (if any)
-export GATES_TO_SKIP_ARR=$(_convert_to_json_array "${GATES_TO_SKIP:-}")
+export GATES_TO_SKIP=$(echo "${GATES_TO_SKIP:-}" | tr ",;| " ",") ## Replace all separators with comma
 
 ENDPOINT_URL="${GH_METRICS_SERVER_ENDPOINT}/quality-gates/required-workflow"
 # shellcheck disable=SC2016
@@ -35,7 +35,6 @@ DATA='{
     "pull_request_deletions": ${PR_NUM_DELETIONS},
     "pull_request_changed_files": ${PR_NUM_CHANGED_FILES},
     "quality_gates_to_skip_str": "${GATES_TO_SKIP}",
-    "quality_gates_to_skip_arr": ${GATES_TO_SKIP_ARR},
     "quality_gate_owner_approval": ${QUALITY_GATE__OWNER_APPROVAL},
     "quality_gate_owner_approval_warn_msgs": "${QUALITY_GATE__OWNER_APPROVAL_WARN_MSGS}",
     "quality_gate_code_review": ${QUALITY_GATE__CODE_REVIEW},

--- a/src/submit_metrics.sh
+++ b/src/submit_metrics.sh
@@ -35,7 +35,7 @@ DATA='{
     "pull_request_deletions": ${PR_NUM_DELETIONS},
     "pull_request_changed_files": ${PR_NUM_CHANGED_FILES},
     "quality_gates_to_skip_str": "${GATES_TO_SKIP}",
-    "quality_gates_to_skip_arr": "${GATES_TO_SKIP_ARR}",
+    "quality_gates_to_skip_arr": ${GATES_TO_SKIP_ARR},
     "quality_gate_owner_approval": ${QUALITY_GATE__OWNER_APPROVAL},
     "quality_gate_owner_approval_warn_msgs": "${QUALITY_GATE__OWNER_APPROVAL_WARN_MSGS}",
     "quality_gate_code_review": ${QUALITY_GATE__CODE_REVIEW},

--- a/src/submit_metrics.sh
+++ b/src/submit_metrics.sh
@@ -20,7 +20,7 @@ export QUALITY_GATE__STATIC_ANALYSIS_VALUE=${QUALITY_GATE__STATIC_ANALYSIS_VALUE
 export QUALITY_GATE__STATIC_ANALYSIS_VALUE=${QUALITY_GATE__STATIC_ANALYSIS_VALUE/.*/} ## Remove decimal places (if any)
 export QUALITY_GATE__STATIC_ANALYSIS_THRESHOLD=${QUALITY_GATE__STATIC_ANALYSIS_THRESHOLD:-null}
 export QUALITY_GATE__STATIC_ANALYSIS_THRESHOLD=${QUALITY_GATE__STATIC_ANALYSIS_THRESHOLD/.*/} ## Remove decimal places (if any)
-export GATES_TO_SKIP=$(echo "${GATES_TO_SKIP:-}" | tr ",;| " ",") ## Replace all separators with comma
+export GATES_TO_SKIP_ARR=$(_convert_to_json_array "${GATES_TO_SKIP:-}")
 
 ENDPOINT_URL="${GH_METRICS_SERVER_ENDPOINT}/quality-gates/required-workflow"
 # shellcheck disable=SC2016
@@ -35,6 +35,7 @@ DATA='{
     "pull_request_deletions": ${PR_NUM_DELETIONS},
     "pull_request_changed_files": ${PR_NUM_CHANGED_FILES},
     "quality_gates_to_skip_str": "${GATES_TO_SKIP}",
+    "quality_gates_to_skip_arr": "${GATES_TO_SKIP_ARR}",
     "quality_gate_owner_approval": ${QUALITY_GATE__OWNER_APPROVAL},
     "quality_gate_owner_approval_warn_msgs": "${QUALITY_GATE__OWNER_APPROVAL_WARN_MSGS}",
     "quality_gate_code_review": ${QUALITY_GATE__CODE_REVIEW},

--- a/src/utils.sh
+++ b/src/utils.sh
@@ -125,3 +125,12 @@ function _retry_with_delay() {
         fi
     done
 }
+
+function _convert_to_json_array() {
+    local input=$1
+    if [ -n "$input" ]; then
+        echo "$input" | tr ",;| " "," | jq -R 'split(",")'
+    else
+        echo "[]"
+    fi
+}

--- a/src/utils.sh
+++ b/src/utils.sh
@@ -125,12 +125,3 @@ function _retry_with_delay() {
         fi
     done
 }
-
-function _convert_to_json_array() {
-    local input=$1
-    if [ -n "$input" ]; then
-        echo "$input" | tr ",;| " "," | jq -R 'split(",")'
-    else
-        echo null
-    fi
-}


### PR DESCRIPTION
## WHAT
- Send data as object, not string
- Return empty array instead of null

## WHY
- When generating the parquet file, pyarrow infers the column type based on its data, if you send `null` the parquet is generated as a string and not string[]

