### PR TITLE
Fix: SonarCloud client _is_sonarcloud_component_exists return

### DIFF
--- a/src/sonarcloud_client.sh
+++ b/src/sonarcloud_client.sh
@@ -28,6 +28,7 @@ function _is_sonarcloud_component_exists() {
     fi
 
     _log debug "${C_WHT}SonarCloud component exists:${C_END} ${_is_exists}"
+    echo "$_is_exists"
 }
 
 function _get_pull_request_infos() {


### PR DESCRIPTION
## WHAT?
- Fix SonarCloud client function, including return instruction

## WHY?
- When the project does not exist, execution continues and an error occurs `jq: error (at <stdin>:1): Cannot iterate over null (null)`

![image](https://github.com/olxbr/quality-gate-action/assets/4138825/7af51e29-2026-4a0c-82c1-d77f8b08f08e)
