### PR TITLE
feat: ignore more than one unit test step configured

### DIFF
--- a/src/unit_test.sh
+++ b/src/unit_test.sh
@@ -35,8 +35,8 @@ function _check_unit_test_status() {
     quality_gate_step=$(_get_quality_gate_unit_test_step "$workflow_run_id")
     _log debug "${C_WHT}Quality Gate Step:${C_END} ${quality_gate_step}"
 
-    status=$(jq -r '.status' <<<"$quality_gate_step")
-    conclusion=$(jq -r '.conclusion' <<<"$quality_gate_step")
+    status=$(jq -r '.status' <<<"$quality_gate_step" | uniq)
+    conclusion=$(jq -r '.conclusion' <<<"$quality_gate_step" | uniq)
 
     if [[ $status == "completed" ]]; then
         succeeded=true


### PR DESCRIPTION
<!--
describe what you did.
-->
### What?
- ignore more than one unit test step configured

<!--
- describe why you did it.
-->
### Why?
- Sometimes people configure more than one unit test step, but the code fails because it expects there to be only one.
