### PR TITLE
Fix: set default input values

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -44,8 +44,8 @@ inputs:
     default: 30
   skip_quality_gate_lock:
     description: "Skip the Quality Gate Lock"
-    type: string
-    default: "false"
+    type: boolean
+    default: false
 
 runs:
   using: "composite"
@@ -70,7 +70,7 @@ runs:
         echo "UNIT_TEST_CHECK_TIMEOUT=${{ inputs.unit_test_check_timeout }}" >> $GITHUB_ENV
         echo "UNIT_TEST_INIT_WAIT_TIMEOUT=${{ inputs.unit_test_init_wait_timeout }}" >> $GITHUB_ENV
         echo "COVERAGE_THRESHOLD=${{ inputs.coverage_threshold }}" >> $GITHUB_ENV
-        echo "SKIP_QUALITY_GATE_LOCK=${{ inputs.skip_quality_gate_lock }}" >> $GITHUB_ENV
+        echo "SKIP_QUALITY_GATE_LOCK=${{ inputs.skip_quality_gate_lock && 'true' || 'false' }}" >> $GITHUB_ENV
 
     - name: "Log Skip Gates Configuration"
       if: ${{ inputs.gates_to_skip != '' }}

--- a/action.yml
+++ b/action.yml
@@ -35,8 +35,12 @@ inputs:
     required: true
   coverage_threshold:
     description: "The minimum acceptable coverage threshold"
+    type: integer
+    default: 30
   skip_quality_gate_lock:
     description: "Skip the Quality Gate Lock"
+    type: boolean
+    default: false
 
 runs:
   using: "composite"

--- a/action.yml
+++ b/action.yml
@@ -45,7 +45,7 @@ inputs:
   skip_quality_gate_lock:
     description: "Skip the Quality Gate Lock"
     type: string
-    default: false
+    default: "false"
 
 runs:
   using: "composite"

--- a/action.yml
+++ b/action.yml
@@ -3,12 +3,15 @@ description: "This action will check the quality gate of the project"
 inputs:
   github_token:
     description: "The GitHub token for the repository"
+    type: string
     required: true
   sonar_token:
     description: "The SonarCloud token for the repository"
+    type: string
     required: true
   docs_url:
     description: "The URL of the documentation"
+    type: string
     required: false
     default: ""
   sonar_check_timeout:
@@ -28,10 +31,12 @@ inputs:
     default: 30
   gates_to_skip:
     description: "The gates to skip (code_review, coverage, owner_approval, static_analysis, unit_test)"
+    type: string
     required: false
     default: ""
   gh_metrics_server_endpoint:
     description: "The endpoint of the GitHub metrics server"
+    type: string
     required: true
   coverage_threshold:
     description: "The minimum acceptable coverage threshold"
@@ -39,7 +44,7 @@ inputs:
     default: 30
   skip_quality_gate_lock:
     description: "Skip the Quality Gate Lock"
-    type: boolean
+    type: string
     default: false
 
 runs:


### PR DESCRIPTION
<!--
describe what you did.
-->
### What?
- Set default input values

<!--
- describe why you did it.
-->
### Why?
- In some cases the value is needed. For example to send metrics to Datalake.

<img width="595" alt="image" src="https://github.com/olxbr/quality-gate-action/assets/4138825/155b7973-fd49-4ada-bab2-8f3ddfd7f074">

<img width="1295" alt="image" src="https://github.com/olxbr/quality-gate-action/assets/4138825/976e94df-80f1-4bde-bbcb-6380dcceb633">

