### PR TITLE
Decrease default timeout for tests check

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -18,12 +18,12 @@ inputs:
     description: "The timeout in minutes for the SonarCloud check"
     type: integer
     required: false
-    default: 60
+    default: 45
   unit_test_check_timeout:
     description: "The timeout in minutes for the unit test check"
     type: integer
     required: false
-    default: 60
+    default: 45
   unit_test_init_wait_timeout:
     description: "The wait time in minutes for the unit test init"
     type: integer


### PR DESCRIPTION
<!--
describe what you did.
-->
### What?
- Decrease default timeout

<!--
- describe why you did it.
-->
### Why?
- To avoid expires token app
