### PR TITLE
Fix(sonarcloud analysis): Fix Env Values When SonarCloud Configs Not Ok

### DIFF
--- a/src/sonarcloud_analysis.sh
+++ b/src/sonarcloud_analysis.sh
@@ -318,13 +318,30 @@ function _check_sonarcloud_analysis() {
             _log debug "${C_YEL}SonarCloud Analysis failed!${C_END}"
             _log debug "${C_YEL}$sonarcloud_analysis_warn_msg${C_END}"
 
-            {
-                echo "QUALITY_GATE__COVERAGE_PASS=false"
-                echo "QUALITY_GATE__COVERAGE_WARN_MSGS=$sonarcloud_analysis_warn_msg"
-                echo "QUALITY_GATE__STATIC_ANALYSIS_PASS=false"
-                echo "QUALITY_GATE__STATIC_ANALYSIS_WARN_MSGS=$sonarcloud_analysis_warn_msg"
-            } >>"$GITHUB_ENV"
+            local cover_msg=""
+            local cover_pass=false
 
+            local static_msg=""
+            local static_pass=false
+
+            if [[ "$skip_coverage" == true ]]; then
+                cover_pass=true
+                cover_msg="Coverage check skipped!"
+                _log debug "${C_YEL}$cover_msg${C_END}"
+            fi
+
+            if [[ "$skip_static_analysis" == true ]]; then
+                static_pass=true
+                static_msg="Static Analysis check skipped!"
+                _log debug "${C_YEL}$static_msg${C_END}"
+            fi
+
+            {
+                echo "QUALITY_GATE__COVERAGE_PASS=$cover_pass"
+                echo "QUALITY_GATE__COVERAGE_WARN_MSGS=${cover_msg:-$sonarcloud_analysis_warn_msg}"
+                echo "QUALITY_GATE__STATIC_ANALYSIS_PASS=$static_pass"
+                echo "QUALITY_GATE__STATIC_ANALYSIS_WARN_MSGS=${static_msg:-$sonarcloud_analysis_warn_msg}"
+            } >>"$GITHUB_ENV"
         fi
     else
         _log warn "${C_YEL}SonarCloud Analysis check skipped!${C_END}"

--- a/src/sonarcloud_analysis.sh
+++ b/src/sonarcloud_analysis.sh
@@ -284,6 +284,7 @@ function _check_sonarcloud_analysis_status() {
 
 # Main function to check SonarCloud Analysis
 function _check_sonarcloud_analysis() {
+    local sonarcloud_analysis_warn_msg=""
     skip_coverage=$(_has_gate_to_skip "coverage")
     skip_static_analysis=$(_has_gate_to_skip "static_analysis")
 
@@ -306,15 +307,24 @@ function _check_sonarcloud_analysis() {
                 _check_static_analysis
             else
                 _log warn "${C_YEL}SonarCloud Analysis not completed!${C_END}"
-                _insert_warning_message QUALITY_GATE__SONARCLOUD_WARN_MSGS "⚠️ SonarCloud Analysis not completed!"
+                _insert_warning_message sonarcloud_analysis_warn_msg "⚠️ SonarCloud Analysis not completed!"
+
             fi
         else
+            _insert_warning_message sonarcloud_analysis_warn_msg "$SONARCLOUD_CFGS_WARN_MSGS"
+        fi
+
+        if [[ -n $sonarcloud_analysis_warn_msg ]]; then
+            _log debug "${C_YEL}SonarCloud Analysis failed!${C_END}"
+            _log debug "${C_YEL}$sonarcloud_analysis_warn_msg${C_END}"
+
             {
                 echo "QUALITY_GATE__COVERAGE_PASS=false"
-                echo "QUALITY_GATE__COVERAGE_WARN_MSGS=$SONARCLOUD_CFGS_WARN_MSGS"
+                echo "QUALITY_GATE__COVERAGE_WARN_MSGS=$sonarcloud_analysis_warn_msg"
                 echo "QUALITY_GATE__STATIC_ANALYSIS_PASS=false"
-                echo "QUALITY_GATE__STATIC_ANALYSIS_WARN_MSGS=$SONARCLOUD_CFGS_WARN_MSGS"
+                echo "QUALITY_GATE__STATIC_ANALYSIS_WARN_MSGS=$sonarcloud_analysis_warn_msg"
             } >>"$GITHUB_ENV"
+
         fi
     else
         _log warn "${C_YEL}SonarCloud Analysis check skipped!${C_END}"


### PR DESCRIPTION
<!--
describe what you did.
-->
### What?
- Fix env values when SonarCloud configs not ok

<!--
- describe why you did it.
-->
### Why?
- We need to validate each skip to set the variables correctly and avoid lock the skipped gate

---

<details><summary>Details</summary>
<h3>Before the fix:</h3>

![image](https://github.com/olxbr/quality-gate-action/assets/4138825/8b191e4a-df85-4924-a7e5-79121ea82f52)

<h3>After:</h3>

![image](https://github.com/olxbr/quality-gate-action/assets/4138825/e1a272bd-6869-4735-956c-24c529b2cc37)
</details>


